### PR TITLE
feat(test-tools): record test outcome as Okahu label on cleanup

### DIFF
--- a/test_tools/src/monocle_test_tools/trace_sources/__init__.py
+++ b/test_tools/src/monocle_test_tools/trace_sources/__init__.py
@@ -1,0 +1,22 @@
+"""Trace-source abstraction for the Monocle test tools."""
+from typing import Optional
+
+from monocle_test_tools.trace_sources.trace_source import TraceSource
+from monocle_test_tools.trace_sources.okahu_trace_source import OkahuTraceSource
+
+__all__ = ["TraceSource", "OkahuTraceSource", "get_trace_source"]
+
+# Known trace sources by name.
+_TRACE_SOURCES = {
+    OkahuTraceSource.name: OkahuTraceSource,
+}
+
+
+def get_trace_source(name: Optional[str]) -> Optional[TraceSource]:
+    """Return a :class:`TraceSource` instance for a source name.
+
+    Returns ``None`` for an unknown or empty name (the caller treats that as
+    "no recording to do").
+    """
+    source_cls = _TRACE_SOURCES.get(name) if name else None
+    return source_cls() if source_cls is not None else None

--- a/test_tools/src/monocle_test_tools/trace_sources/okahu_trace_source.py
+++ b/test_tools/src/monocle_test_tools/trace_sources/okahu_trace_source.py
@@ -1,0 +1,88 @@
+"""Okahu trace source.
+
+Records a test's pass/fail outcome back to Okahu as an evaluation label via
+``POST /v1/eval/label`` (server side:
+``okahu/observability/azure-fn/eval-api/function_app.py::eval_label``).
+"""
+import logging
+import os
+from typing import Optional
+
+import requests
+
+from monocle_test_tools.trace_sources.trace_source import TraceSource
+
+logger = logging.getLogger(__name__)
+
+OKAHU_PROD_EVALUATION_ENDPOINT = "https://eval.okahu.co/api"
+
+# Class name of the Okahu span exporter, matched by name so this module does not
+# need to import the apptrace exporter package just to detect it.
+OKAHU_EXPORTER_CLASS_NAME = "OkahuSpanExporter"
+
+
+class OkahuTraceSource(TraceSource):
+    """Trace source backed by the Okahu cloud service."""
+
+    name = "okahu"
+
+    def record_test_result(self, *, fact_id: Optional[str], fact_name: Optional[str],
+                           workflow_name: Optional[str], test_name: str,
+                           test_failed: bool, exporters: Optional[list] = None,
+                           description: str = "Test run") -> bool:
+        """Record the test outcome as an Okahu eval label.
+
+        Best-effort: returns ``False`` (and logs at most a warning) when the
+        preconditions aren't met or the request fails. Never raises, so it can't
+        fail the test or mask its real result.
+        """
+        if not self._okahu_exporter_active(exporters):
+            logger.debug("No Okahu exporter active; skipping test-result label.")
+            return False
+
+        api_key = (os.getenv("OKAHU_API_KEY") or "").strip()
+        if not api_key:
+            logger.debug("OKAHU_API_KEY not set; skipping test-result label.")
+            return False
+
+        if not fact_id or not workflow_name:
+            logger.debug("Missing fact_id or workflow_name; skipping test-result label.")
+            return False
+
+        base = os.getenv("OKAHU_EVALUATION_ENDPOINT", OKAHU_PROD_EVALUATION_ENDPOINT).rstrip("/")
+        value = "FAIL" if test_failed else "PASS"
+        payload = {
+            "result": {
+                "label": test_name,
+                "value": value,
+                "description": description,
+                "type": "test",
+            }
+        }
+
+        try:
+            response = requests.post(
+                url=f"{base}/v1/eval/label",
+                headers={"x-api-key": api_key},
+                json=payload,
+                params={
+                    "trace_id": fact_id,
+                    "fact_name": fact_name or "traces",
+                    "workflow_name": workflow_name,
+                },
+                timeout=60,
+            )
+            response.raise_for_status()
+        except Exception as exc:  # best-effort: never let recording break a test
+            logger.warning("Failed to record test result label to Okahu: %s", exc)
+            return False
+
+        logger.debug("Recorded test result label for '%s' (%s) to Okahu.", test_name, value)
+        return True
+
+    @staticmethod
+    def _okahu_exporter_active(exporters: Optional[list]) -> bool:
+        """Return True if an Okahu span exporter is present in ``exporters``."""
+        if not exporters:
+            return False
+        return any(type(e).__name__ == OKAHU_EXPORTER_CLASS_NAME for e in exporters)

--- a/test_tools/src/monocle_test_tools/trace_sources/trace_source.py
+++ b/test_tools/src/monocle_test_tools/trace_sources/trace_source.py
@@ -1,0 +1,47 @@
+"""Trace-source abstraction.
+
+A ``TraceSource`` represents where a test's spans come from (Okahu, a local
+file, ...) and what side effects that source supports around a test run. Today
+the only behavior modeled here is recording a test outcome back to the source
+(see :meth:`TraceSource.record_test_result`); the existing span loaders
+(``OkahuSpanLoader``, ``JSONSpanLoader``) are expected to migrate under this
+abstraction in the future, so the interface is intentionally kept general.
+"""
+from abc import ABC
+from typing import Optional
+
+
+class TraceSource(ABC):
+    """Base class for trace sources.
+
+    ``record_test_result`` is a concrete no-op by default so sources that don't
+    support recording an outcome (e.g. a local file source) inherit the no-op
+    without extra code. Sources that do support it override the method.
+    """
+
+    #: Short name of the source, matching the ``trace_source`` string used by
+    #: ``MonocleValidator`` (e.g. ``"okahu"``, ``"file"``).
+    name: str = ""
+
+    def record_test_result(self, *, fact_id: Optional[str], fact_name: Optional[str],
+                           workflow_name: Optional[str], test_name: str,
+                           test_failed: bool, exporters: Optional[list] = None,
+                           description: str = "Test run") -> bool:
+        """Record a test's outcome back to the trace source.
+
+        Args:
+            fact_id: The id of the fact the test's spans belong to (a trace id,
+                session id, custom scope id, ...).
+            fact_name: The source-side fact name the ``fact_id`` refers to.
+            workflow_name: The workflow / service name the trace belongs to.
+            test_name: The test's name; used as the recorded label.
+            test_failed: Whether the test failed.
+            exporters: The exporters the validator has configured, so a source
+                can decide whether it is the active export target.
+            description: Free-text description stored with the record.
+
+        Returns:
+            ``True`` if a record was successfully written, ``False`` otherwise
+            (including the default no-op).
+        """
+        return False

--- a/test_tools/src/monocle_test_tools/validator.py
+++ b/test_tools/src/monocle_test_tools/validator.py
@@ -26,6 +26,7 @@ from monocle_test_tools.schema import SpanType, TestSpan, TestCase, MultiTurnTes
 from monocle_test_tools.constants import TEST_SCOPE_NAME, SESSION_SCOPE_NAME, DEFAULT_WORKFLOW_NAME, TEST_STATUS_ATTRIBUTE, TEST_ASSERTION_ATTRIBUTE, TEST_WORKFLOW_ENV
 from monocle_test_tools.comparer.base_comparer import BaseComparer
 from monocle_test_tools.runner.runner import get_agent_runner
+from monocle_test_tools.trace_sources import get_trace_source
 from monocle_test_tools import trace_utils
 from monocle_apptrace.instrumentation.metamodel.adk.methods import ADK_METHODS
 from monocle_apptrace.instrumentation.metamodel.adk.entities.tool import TOOL as ADK_TOOL
@@ -62,6 +63,12 @@ class MonocleValidator:
         self._spans:tuple[Span] = ()
         self._test_all_up_spans:tuple[Span] = ()
         self._trace_source: str = ""
+        # Details of the fact whose spans were loaded from a remote trace source,
+        # captured in import_traces and used to record the test outcome back to
+        # the source during post_test_cleanup.
+        self._trace_source_fact_id: Optional[str] = None
+        self._trace_source_fact_name: Optional[str] = None
+        self._trace_source_workflow_name: Optional[str] = None
         test_trace_path:str = os.path.join(".", DEFAULT_TRACE_FOLDER, "test_traces")
         os.environ["MONOCLE_TRACE_OUTPUT_PATH"] = test_trace_path
         if exporter_list is None:
@@ -100,6 +107,9 @@ class MonocleValidator:
         if self.file_exporter is not None:
             self.file_exporter.force_flush()
         self.trace_id = None
+        self._trace_source_fact_id = None
+        self._trace_source_fact_name = None
+        self._trace_source_workflow_name = None
 
     @property
     def spans(self):
@@ -181,10 +191,37 @@ class MonocleValidator:
         try:
             if not skip_export:
                 self.flush_to_exporters(test_name, test_failed, test_assertion_message)
+            self._maybe_record_test_result(test_name, test_failed)
         finally:
             self.cleanup()
             if token is not None:
                 stop_scope(token)
+
+    def _maybe_record_test_result(self, test_name:str, test_failed:bool) -> None:
+        """Record the test outcome back to the trace source, when supported.
+
+        Resolves the current trace source (only Okahu records today) and asks it
+        to record a label for this test. Fully best-effort: it never raises, so
+        it cannot fail the test or mask its real result. Must run before
+        ``cleanup()`` clears the captured fact details.
+        """
+        try:
+            trace_source = get_trace_source(self._trace_source)
+            if trace_source is None:
+                return
+            fact_id = self._trace_source_fact_id or self._get_current_trace_id()
+            fact_name = self._trace_source_fact_name or "traces"
+            workflow_name = self._trace_source_workflow_name or get_workflow_name()
+            trace_source.record_test_result(
+                fact_id=fact_id,
+                fact_name=fact_name,
+                workflow_name=workflow_name,
+                test_name=test_name,
+                test_failed=test_failed,
+                exporters=self.exporters,
+            )
+        except Exception as exc:
+            logger.warning("Failed to record test result: %s", exc)
 
     @contextmanager
     def monocle_exporter_wrapper(self, test_case: TestCase, request:pytest.FixtureRequest):
@@ -610,26 +647,34 @@ class MonocleValidator:
 
             if fact_name == "session":
                 # Session-based: use agent_sessions scope
+                okahu_fact_name = OkahuSpanLoader.AGENT_SESSIONS_SCOPE
                 spans = OkahuSpanLoader.load_by_scope(
                     workflow_name=workflow_name,
-                    scope_name=OkahuSpanLoader.AGENT_SESSIONS_SCOPE,
+                    scope_name=okahu_fact_name,
                     scope_id=id,
                 )
             elif fact_name == "scope":
                 # Custom scope: requires scope_name
                 if not scope_name:
                     raise ValueError("'scope_name' is required when fact_name='scope'.")
+                okahu_fact_name = scope_name
                 spans = OkahuSpanLoader.load_by_scope(
                     workflow_name=workflow_name,
-                    scope_name=scope_name,
+                    scope_name=okahu_fact_name,
                     scope_id=id,
                 )
             else:
                 # Direct trace_id lookup
+                okahu_fact_name = "traces"
                 spans = OkahuSpanLoader.get_spans(
                     workflow_name=workflow_name,
                     trace_id=id,
                 )
+            # Capture the fact details so the test outcome can be recorded back
+            # to Okahu during post_test_cleanup.
+            self._trace_source_fact_id = id
+            self._trace_source_fact_name = okahu_fact_name
+            self._trace_source_workflow_name = workflow_name
         else:
             # File source — fact_name must be "trace"
             if fact_name != "trace":

--- a/test_tools/tests/unit/test_okahu_trace_source.py
+++ b/test_tools/tests/unit/test_okahu_trace_source.py
@@ -1,0 +1,169 @@
+"""Unit tests for the trace-source abstraction and the Okahu test-result label.
+
+Covers:
+- ``get_trace_source`` name resolution.
+- ``OkahuTraceSource.record_test_result`` request shape, PASS/FAIL mapping, and
+  its best-effort gating / failure handling.
+"""
+import requests
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monocle_test_tools.trace_sources import (
+    OkahuTraceSource,
+    TraceSource,
+    get_trace_source,
+)
+
+
+class _FakeOkahuSpanExporter:
+    """Stand-in whose class name matches what the source detects."""
+
+
+# Ensure the detected class name matches the real exporter's name.
+_FakeOkahuSpanExporter.__name__ = "OkahuSpanExporter"
+
+
+class _OtherExporter:
+    pass
+
+
+def _ok_response():
+    response = MagicMock(spec=requests.Response)
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _record(source, monkeypatch, **overrides):
+    """Call record_test_result with sensible defaults, returning (result, mock_post)."""
+    monkeypatch.setenv("OKAHU_API_KEY", overrides.pop("api_key", "test-key"))
+    kwargs = dict(
+        fact_id="abc123",
+        fact_name="traces",
+        workflow_name="my_app",
+        test_name="test_something",
+        test_failed=False,
+        exporters=[_FakeOkahuSpanExporter()],
+    )
+    kwargs.update(overrides)
+    with patch("monocle_test_tools.trace_sources.okahu_trace_source.requests.post") as mock_post:
+        mock_post.return_value = _ok_response()
+        result = source.record_test_result(**kwargs)
+    return result, mock_post
+
+
+class TestGetTraceSource:
+    def test_okahu_returns_okahu_source(self):
+        assert isinstance(get_trace_source("okahu"), OkahuTraceSource)
+
+    @pytest.mark.parametrize("name", ["file", "unknown", "", None])
+    def test_other_returns_none(self, name):
+        assert get_trace_source(name) is None
+
+
+class TestBaseTraceSource:
+    def test_default_record_is_noop(self):
+        class Bare(TraceSource):
+            name = "bare"
+
+        assert Bare().record_test_result(
+            fact_id="x", fact_name="traces", workflow_name="w",
+            test_name="t", test_failed=False,
+        ) is False
+
+
+class TestOkahuRecordTestResult:
+    def test_pass_posts_expected_request(self, monkeypatch):
+        source = OkahuTraceSource()
+        result, mock_post = _record(source, monkeypatch)
+
+        assert result is True
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["url"].endswith("/v1/eval/label")
+        assert kwargs["params"] == {
+            "trace_id": "abc123",
+            "fact_name": "traces",
+            "workflow_name": "my_app",
+        }
+        assert kwargs["headers"] == {"x-api-key": "test-key"}
+        assert kwargs["json"] == {
+            "result": {
+                "label": "test_something",
+                "value": "PASS",
+                "description": "Test run",
+                "type": "test",
+            }
+        }
+
+    def test_failed_maps_to_fail_value(self, monkeypatch):
+        source = OkahuTraceSource()
+        result, mock_post = _record(source, monkeypatch, test_failed=True)
+
+        assert result is True
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["result"]["value"] == "FAIL"
+
+    def test_custom_fact_passed_through(self, monkeypatch):
+        source = OkahuTraceSource()
+        _, mock_post = _record(source, monkeypatch, fact_name="agent_sessions", fact_id="sess-1")
+        _, kwargs = mock_post.call_args
+        assert kwargs["params"]["fact_name"] == "agent_sessions"
+        assert kwargs["params"]["trace_id"] == "sess-1"
+
+    def test_noop_without_okahu_exporter(self, monkeypatch):
+        source = OkahuTraceSource()
+        result, mock_post = _record(source, monkeypatch, exporters=[_OtherExporter()])
+        assert result is False
+        mock_post.assert_not_called()
+
+    def test_noop_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("OKAHU_API_KEY", raising=False)
+        source = OkahuTraceSource()
+        with patch("monocle_test_tools.trace_sources.okahu_trace_source.requests.post") as mock_post:
+            result = source.record_test_result(
+                fact_id="abc123", fact_name="traces", workflow_name="my_app",
+                test_name="t", test_failed=False, exporters=[_FakeOkahuSpanExporter()],
+            )
+        assert result is False
+        mock_post.assert_not_called()
+
+    @pytest.mark.parametrize("missing", [{"fact_id": None}, {"workflow_name": None}])
+    def test_noop_without_ids(self, monkeypatch, missing):
+        source = OkahuTraceSource()
+        result, mock_post = _record(source, monkeypatch, **missing)
+        assert result is False
+        mock_post.assert_not_called()
+
+    def test_best_effort_on_network_error(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_API_KEY", "test-key")
+        source = OkahuTraceSource()
+        with patch("monocle_test_tools.trace_sources.okahu_trace_source.requests.post") as mock_post:
+            mock_post.side_effect = requests.ConnectionError("boom")
+            result = source.record_test_result(
+                fact_id="abc123", fact_name="traces", workflow_name="my_app",
+                test_name="t", test_failed=False, exporters=[_FakeOkahuSpanExporter()],
+            )
+        assert result is False
+
+    def test_best_effort_on_non_2xx(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_API_KEY", "test-key")
+        source = OkahuTraceSource()
+        response = MagicMock(spec=requests.Response)
+        response.raise_for_status.side_effect = requests.HTTPError("500")
+        with patch("monocle_test_tools.trace_sources.okahu_trace_source.requests.post") as mock_post:
+            mock_post.return_value = response
+            result = source.record_test_result(
+                fact_id="abc123", fact_name="traces", workflow_name="my_app",
+                test_name="t", test_failed=False, exporters=[_FakeOkahuSpanExporter()],
+            )
+        assert result is False
+
+    def test_endpoint_override(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_EVALUATION_ENDPOINT", "https://custom.example/api/")
+        source = OkahuTraceSource()
+        _, mock_post = _record(source, monkeypatch)
+        _, kwargs = mock_post.call_args
+        assert kwargs["url"] == "https://custom.example/api/v1/eval/label"

--- a/test_tools/tests/unit/test_validator_record_result.py
+++ b/test_tools/tests/unit/test_validator_record_result.py
@@ -1,0 +1,84 @@
+"""Unit tests for MonocleValidator wiring of test-result recording.
+
+Covers that ``import_traces`` captures the okahu fact details and that
+``post_test_cleanup`` routes them to the resolved trace source's
+``record_test_result``.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monocle_test_tools import MonocleValidator
+
+
+@pytest.fixture
+def validator():
+    v = MonocleValidator()
+    v.cleanup()
+    yield v
+    v.cleanup()
+    v._trace_source = ""
+
+
+class TestImportTracesCaptures:
+    @pytest.mark.parametrize(
+        "kwargs, expected_fact_name",
+        [
+            (dict(id="trace-1"), "traces"),
+            (dict(id="sess-1", fact_name="session"), "agent_sessions"),
+            (dict(id="scope-1", fact_name="scope", scope_name="test_id"), "test_id"),
+        ],
+    )
+    def test_captures_okahu_fact_details(self, validator, kwargs, expected_fact_name):
+        with patch("monocle_test_tools.validator.OkahuSpanLoader") as loader:
+            loader.AGENT_SESSIONS_SCOPE = "agent_sessions"
+            loader.get_spans.return_value = []
+            loader.load_by_scope.return_value = []
+            validator.import_traces(trace_source="okahu", workflow_name="my_app", **kwargs)
+
+        assert validator._trace_source_fact_id == kwargs["id"]
+        assert validator._trace_source_fact_name == expected_fact_name
+        assert validator._trace_source_workflow_name == "my_app"
+
+
+class TestPostTestCleanupRecords:
+    def test_records_for_okahu_source(self, validator):
+        validator._trace_source = "okahu"
+        validator._trace_source_fact_id = "trace-1"
+        validator._trace_source_fact_name = "traces"
+        validator._trace_source_workflow_name = "my_app"
+
+        fake_source = MagicMock()
+        with patch("monocle_test_tools.validator.get_trace_source", return_value=fake_source) as gts:
+            validator.post_test_cleanup(
+                token=None, test_name="test_x", test_failed=True, skip_export=True
+            )
+
+        gts.assert_called_once_with("okahu")
+        fake_source.record_test_result.assert_called_once()
+        _, kwargs = fake_source.record_test_result.call_args
+        assert kwargs["fact_id"] == "trace-1"
+        assert kwargs["fact_name"] == "traces"
+        assert kwargs["workflow_name"] == "my_app"
+        assert kwargs["test_name"] == "test_x"
+        assert kwargs["test_failed"] is True
+        assert kwargs["exporters"] is validator.exporters
+
+    def test_noop_for_non_okahu_source(self, validator):
+        validator._trace_source = "file"
+        # Real get_trace_source("file") -> None, so nothing should be recorded
+        # and no error should be raised.
+        validator.post_test_cleanup(
+            token=None, test_name="test_x", test_failed=False, skip_export=True
+        )
+
+    def test_recording_failure_never_raises(self, validator):
+        validator._trace_source = "okahu"
+        validator._trace_source_fact_id = "trace-1"
+        fake_source = MagicMock()
+        fake_source.record_test_result.side_effect = RuntimeError("boom")
+        with patch("monocle_test_tools.validator.get_trace_source", return_value=fake_source):
+            # Must not raise.
+            validator.post_test_cleanup(
+                token=None, test_name="test_x", test_failed=False, skip_export=True
+            )


### PR DESCRIPTION
## What

Records a test's pass/fail verdict back to Okahu as an evaluation label when the test's spans come from the Okahu trace source, so the Monocle test framework's verdict is visible alongside the trace in Okahu.

## How

- New `TraceSource` abstraction under `test_tools/src/monocle_test_tools/trace_sources/`:
  - `TraceSource` ABC with an overridable, default no-op `record_test_result(...)`. Kept general so the existing span loaders (`OkahuSpanLoader`, `JSONSpanLoader`) can migrate under it later.
  - `OkahuTraceSource` — owns all Okahu specifics and posts to `POST /v1/eval/label`.
  - `get_trace_source(name)` factory.
- `MonocleValidator`:
  - Captures the loaded fact's id / Okahu fact name / workflow name in `import_traces` (mapping `trace`→`traces`, `session`→`agent_sessions`, `scope`→scope name), reset in `cleanup()`.
  - `post_test_cleanup` calls `_maybe_record_test_result(...)` after flush, before cleanup.

## Behavior

Recorded body: `{"result": {"label": <test_name>, "value": "PASS"|"FAIL", "description": "Test run", "type": "test"}}` with `trace_id` / `fact_name` / `workflow_name` query params.

Recording fires **only** when all hold:
1. trace source is `okahu`,
2. an `OkahuSpanExporter` is active,
3. `OKAHU_API_KEY` is set,
4. a fact id and workflow name are available.

It is **best-effort**: any failure (missing key, network, non-2xx) logs a warning and never fails the test or masks its real result. Works for all facts (trace / session / scope).

## Tests

- 22 new unit tests (`test_okahu_trace_source.py`, `test_validator_record_result.py`): request shape, PASS/FAIL mapping, all gating no-op paths, best-effort failure handling, fact-detail capture, and cleanup routing.
- Full `test_tools` unit suite shows no new failures versus baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)